### PR TITLE
Updates and new features

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[rest_api]
-        pip install pytest coverage python-coveralls
+        pip install pytest pytest-cov
     - name: Run regular unit tests
       run: |
-        pytest protmapper --cov=protmapper
+        pytest protmapper/tests --cov=protmapper
     - name: Run CLI smoketests
       run: |
         protmapper protmapper/tests/cli_input.csv output.csv --no_methionine_offset --no_orthology_mapping --no_isoform_mapping

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.12"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -13,10 +16,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[rest_api]
-        pip install nose coverage python-coveralls
+        pip install pytest coverage python-coveralls
     - name: Run regular unit tests
       run: |
-        nosetests protmapper -v --with-coverage --cover-inclusive --cover-package=protmapper
+        pytest protmapper --cov=protmapper
     - name: Run CLI smoketests
       run: |
         protmapper protmapper/tests/cli_input.csv output.csv --no_methionine_offset --no_orthology_mapping --no_isoform_mapping

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[rest_api]
-        pip install pytest pytest-cov
+        pip install .[rest_api,tests]
     - name: Run regular unit tests
       run: |
         pytest protmapper/tests --cov=protmapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.11
 
 RUN pip install protmapper[rest_api] && \
     python -m protmapper.resources

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018, INDRA Labs
+Copyright (c) 2024, Gyori lab
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ The Protmapper maps protein sites to the human reference
 sequence based on UniProt, PhosphoSitePlus, and manual curation.
 
 
-## Installation
+## Installation and usage
 
 ### Python package
 The Protmapper is a Python package that is available on PyPI and can be
 installed as:
 
-```
+```bash
 pip install protmapper
 ```
 
@@ -17,11 +17,27 @@ pip install protmapper
 Protmapper can be run as a local service via a Docker container exposing a
 REST API as:
 
-```
+```bash
 docker run -d -p 8008:8008 gyorilab/protmapper:latest
 ```
 
-## Command line interface
+Example: once the container is running, you can send requests to the REST API
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"site_list": [["P28482", "uniprot", "T", "184"]]}' http://localhost:8008/map_sitelist_to_human_ref
+```
+
+which is equivalent to the following Python code using the `requests` package
+
+```python
+import requests
+url = 'http://localhost:8008/map_sitelist_to_human_ref'
+data = {'site_list': [['P28482', 'uniprot', 'T', '184']]}
+response = requests.post(url, json=data)
+print(response.json())
+```
+
+### Command line interface
 In addition to supporting usage via a Python API and a REST service,
 Protmapper also provides a command line interface that can be used as follows.
 
@@ -61,8 +77,35 @@ optional arguments:
   --no_isoform_mapping  If given, will not check sequence positions for known
                         modifications in other human isoforms of the protein
                         (based on PhosphoSitePlus data).
-
 ```
+
+Example: the sample file [cli_input.csv](https://raw.githubusercontent.com/gyorilab/protmapper/master/protmapper/tests/cli_input.csv)
+has the following content
+
+```csv
+MAPK1,hgnc,T,183
+MAPK1,hgnc,T,184
+MAPK1,hgnc,T,185
+MAPK1,hgnc,T,186
+```
+
+By running the following command
+
+```bash
+protmapper cli_input.csv output.csv
+```
+
+we get `output.csv` which has the following content
+
+```csv
+up_id,error_code,valid,orig_res,orig_pos,mapped_id,mapped_res,mapped_pos,description,gene_name
+P28482,,False,T,183,P28482,T,185,INFERRED_MOUSE_SITE,MAPK1
+P28482,,False,T,184,P28482,T,185,INFERRED_METHIONINE_CLEAVAGE,MAPK1
+P28482,,True,T,185,,,,VALID,MAPK1
+P28482,,False,T,186,,,,NO_MAPPING_FOUND,MAPK1
+```
+
+
 
 ## Documentation
 For a detailed documentation of the Protmapper, visit http://protmapper.readthedocs.io
@@ -74,13 +117,13 @@ and HR00112220036.
 ## Citation
 
 ```bibtex
-@article{bachman2019protmapper,
-  author = {Bachman, John A and Gyori, Benjamin M and Sorger, Peter K},
+@article{bachman2022protmapper,
+  author = {Bachman, John A and Sorger, Peter K and Gyori, Benjamin M},
   doi = {10.1101/822668},
   journal = {bioRxiv},
   publisher = {Cold Spring Harbor Laboratory},
-  title = {{Assembling a phosphoproteomic knowledge base using ProtMapper to normalize phosphosite information from databases and text mining}},
-  url = {https://www.biorxiv.org/content/early/2019/11/06/822668.1},
-  year = {2019}
+  title = {{Assembling a corpus of phosphoproteomic annotations using ProtMapper to normalize site information from databases and text mining}},
+  url = {https://www.biorxiv.org/content/10.1101/822668v4},
+  year = {2022}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Protmapper
-The Protmapper maps references to protein sites to the human reference
+The Protmapper maps protein sites to the human reference
 sequence based on UniProt, PhosphoSitePlus, and manual curation.
 
 
@@ -14,11 +14,11 @@ pip install protmapper
 ```
 
 ### Docker container
-Alternatively, the Protmapper Docker container can be run to expose it as
-a REST API as:
+Protmapper can be run as a local service via a Docker container exposing a
+REST API as:
 
 ```
-docker run -d -p 8008:8008 labsyspharm/protmapper:latest
+docker run -d -p 8008:8008 gyorilab/protmapper:latest
 ```
 
 ## Command line interface
@@ -39,7 +39,7 @@ positional arguments:
                         on the protein.
   output                Path to the output file to be generated. Each line of
                         the output file corresponds to a line in the input
-                        file. Each linerepresents a mapped site produced by
+                        file. Each line represents a mapped site produced by
                         Protmapper.
 
 optional arguments:
@@ -68,7 +68,8 @@ optional arguments:
 For a detailed documentation of the Protmapper, visit http://protmapper.readthedocs.io
 
 ## Funding
-The development of protmapper is funded under the DARPA Automated Scientific Discovery Framework project (ARO grant W911NF018-1-0124).
+The development of Protmapper is funded under the DARPA grants W911NF018-1-0124
+and HR00112220036.
 
 ## Citation
 

--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -15,5 +15,5 @@ logging.getLogger('botocore').setLevel(logging.CRITICAL)
 logger = logging.getLogger('protmapper')
 
 if not os.environ.get('INITIAL_RESOURCE_DOWNLOAD'):
-    from protmapper.api import ProtMapper, MappedSite
+    from protmapper.api import *
     from protmapper.resources import resource_dir

--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,4 +1,9 @@
+__all__ = ['map_sitelist_to_human_ref', 'MappedSite', 'InvalidSiteException',
+           'ProtMapper', 'default_mapper', 'resource_dir']
+
+
 __version__ = '0.0.29'
+
 import os
 import logging
 

--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,5 +1,6 @@
-__all__ = ['map_sites', 'MappedSite', 'InvalidSiteException',
-           'ProtMapper', 'default_mapper', 'resource_dir']
+__all__ = ['map_sites', 'get_site_annotations', 'MappedSite',
+           'InvalidSiteException', 'ProtMapper', 'default_mapper',
+           'resource_dir']
 
 
 __version__ = '0.0.29'

--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['map_sitelist_to_human_ref', 'MappedSite', 'InvalidSiteException',
+__all__ = ['map_sites', 'MappedSite', 'InvalidSiteException',
            'ProtMapper', 'default_mapper', 'resource_dir']
 
 

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -5,6 +5,7 @@ import os
 import csv
 import pickle
 import logging
+import tqdm
 from requests.exceptions import HTTPError
 from protmapper.resources import resource_dir_path
 from protmapper import phosphosite_client, uniprot_client
@@ -288,9 +289,9 @@ class ProtMapper(object):
             the input list.
         """
         mapped_sites = []
-        for ix, (prot_id, prot_ns, residue, position) in enumerate(site_list):
-            logger.info("Mapping site %d of %d, cache size %d" %
-                        (ix + 1, len(site_list), len(self._cache)))
+        for ix, (prot_id, prot_ns, residue, position) in \
+                tqdm.tqdm(enumerate(site_list), desc='Mapping sites',
+                          total=len(site_list)):
             try:
                 ms = self.map_to_human_ref(
                     prot_id, prot_ns, residue, position,

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -1,4 +1,4 @@
-__all__ = ['map_sitelist_to_human_ref', 'MappedSite', 'InvalidSiteException',
+__all__ = ['map_sites', 'MappedSite', 'InvalidSiteException',
            'ProtMapper', 'default_mapper']
 
 import os
@@ -18,9 +18,8 @@ valid_aas = ('A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L',
              'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y')
 
 
-def map_sitelist_to_human_ref(site_list, do_methionine_offset=True,
-                              do_orthology_mapping=True,
-                              do_isoform_mapping=True):
+def map_sites(site_list, do_methionine_offset=True, do_orthology_mapping=True,
+              do_isoform_mapping=True):
     """Return a list of mapped sites for a list of input sites.
 
     Parameters

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -1,3 +1,6 @@
+__all__ = ['map_sitelist_to_human_ref', 'MappedSite', 'InvalidSiteException',
+           'ProtMapper', 'default_mapper']
+
 import os
 import csv
 import pickle
@@ -12,6 +15,46 @@ logger = logging.getLogger(__name__)
 
 valid_aas = ('A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L',
              'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y')
+
+
+def map_sitelist_to_human_ref(site_list, do_methionine_offset=True,
+                              do_orthology_mapping=True,
+                              do_isoform_mapping=True):
+    """Return a list of mapped sites for a list of input sites.
+
+    Parameters
+    ----------
+    site_list : list of tuple
+        Each tuple in the list consists of the following entries:
+        (prot_id, prot_ns, residue, position).
+    do_methionine_offset : boolean
+        Whether to check for off-by-one errors in site position (possibly)
+        attributable to site numbering from mature proteins after
+        cleavage of the initial methionine. If True, checks the reference
+        sequence for a known modification at 1 site position greater
+        than the given one; if there exists such a site, creates the
+        mapping. Default is True.
+    do_orthology_mapping : boolean
+        Whether to check sequence positions for known modification sites
+        in mouse or rat sequences (based on PhosphoSitePlus data). If a
+        mouse/rat site is found that is linked to a site in the human
+        reference sequence, a mapping is created. Default is True.
+    do_isoform_mapping : boolean
+        Whether to check sequence positions for known modifications
+        in other human isoforms of the protein (based on PhosphoSitePlus
+        data). If a site is found that is linked to a site in the human
+        reference sequence, a mapping is created. Default is True.
+
+    Returns
+    -------
+    list of :py:class:`protmapper.api.MappedSite`
+        A list of MappedSite objects, one corresponding to each site in
+        the input list.
+    """
+    return default_mapper.map_sitelist_to_human_ref(
+        site_list, do_methionine_offset=do_methionine_offset,
+        do_orthology_mapping=do_orthology_mapping,
+        do_isoform_mapping=do_isoform_mapping)
 
 
 class InvalidSiteException(Exception):
@@ -210,7 +253,9 @@ class ProtMapper(object):
         except:
             pass
 
-    def map_sitelist_to_human_ref(self, site_list, **kwargs):
+    def map_sitelist_to_human_ref(self, site_list, do_methionine_offset=True,
+                                  do_orthology_mapping=True,
+                                  do_isoform_mapping=True):
         """Return a list of mapped sites for a list of input sites.
 
         Parameters
@@ -218,6 +263,23 @@ class ProtMapper(object):
         site_list : list of tuple
             Each tuple in the list consists of the following entries:
             (prot_id, prot_ns, residue, position).
+        do_methionine_offset : boolean
+            Whether to check for off-by-one errors in site position (possibly)
+            attributable to site numbering from mature proteins after
+            cleavage of the initial methionine. If True, checks the reference
+            sequence for a known modification at 1 site position greater
+            than the given one; if there exists such a site, creates the
+            mapping. Default is True.
+        do_orthology_mapping : boolean
+            Whether to check sequence positions for known modification sites
+            in mouse or rat sequences (based on PhosphoSitePlus data). If a
+            mouse/rat site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
+        do_isoform_mapping : boolean
+            Whether to check sequence positions for known modifications
+            in other human isoforms of the protein (based on PhosphoSitePlus
+            data). If a site is found that is linked to a site in the human
+            reference sequence, a mapping is created. Default is True.
 
         Returns
         -------
@@ -230,8 +292,11 @@ class ProtMapper(object):
             logger.info("Mapping site %d of %d, cache size %d" %
                         (ix + 1, len(site_list), len(self._cache)))
             try:
-                ms = self.map_to_human_ref(prot_id, prot_ns, residue, position,
-                                           **kwargs)
+                ms = self.map_to_human_ref(
+                    prot_id, prot_ns, residue, position,
+                    do_methionine_offset=do_methionine_offset,
+                    do_orthology_mapping=do_orthology_mapping,
+                    do_isoform_mapping=do_isoform_mapping)
                 mapped_sites.append(ms)
             except Exception as e:
                 logger.error("Error occurred mapping site "

--- a/protmapper/phosphosite_client.py
+++ b/protmapper/phosphosite_client.py
@@ -1,7 +1,6 @@
 import csv
 import gzip
 import logging
-from os.path import dirname, abspath, join
 from collections import namedtuple, defaultdict
 from protmapper.resources import resource_manager
 

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -397,6 +397,32 @@ def download_refseq_uniprot(out_file, cached=True):
         writer.writerows(filt_rows)
 
 
+def download_annotations(out_file, cached=True):
+    url = ('https://raw.githubusercontent.com/gyorilab/protmapper_paper/master/'
+           'output/export.csv')
+    logger.info('Downloading annotations from %s' % url)
+    res = requests.get(url)
+    if res.status_code != 200:
+        logger.error('Failed to download "%s"' % url)
+        return
+    logger.info('Saving into %s' % out_file)
+    with open(out_file, 'wb') as fh:
+        fh.write(res.content)
+
+
+def download_annotations_evidence(out_file, cached=True):
+    url = ('https://raw.githubusercontent.com/gyorilab/protmapper_paper/master/'
+           'output/evidences.csv')
+    logger.info('Downloading annotation evidence from %s' % url)
+    res = requests.get(url)
+    if res.status_code != 200:
+        logger.error('Failed to download "%s"' % url)
+        return
+    logger.info('Saving into %s' % out_file)
+    with open(out_file, 'wb') as fh:
+        fh.write(res.content)
+
+
 RESOURCE_MAP = {
     'hgnc': ('hgnc_entries.tsv.gz', download_hgnc_entries),
     'upsec': ('uniprot_sec_ac.txt.gz', download_uniprot_sec_ac),
@@ -406,6 +432,8 @@ RESOURCE_MAP = {
     'isoforms': ('uniprot_sprot_varsplic.fasta.gz', download_isoforms),
     'refseq_uniprot': ('refseq_uniprot.csv.gz', download_refseq_uniprot),
     'refseq_seq': ('refseq_sequence.fasta.gz', download_refseq_seq),
+    'annotations': ('annotations.csv', download_annotations),
+    'annotations_evidence': ('annotations_evidence.csv', download_annotations_evidence),
     }
 
 

--- a/protmapper/rest_api/api.py
+++ b/protmapper/rest_api/api.py
@@ -1,7 +1,7 @@
 import json
 from flask import Flask, request, abort, Response, jsonify
 from flask_cors import CORS
-from protmapper import ProtMapper
+from protmapper import ProtMapper, get_site_annotations
 
 
 app = Flask(__name__)
@@ -53,3 +53,17 @@ def map_sitelist_to_human_ref():
 
     ms_list = pm.map_sitelist_to_human_ref(**arg_values)
     return jsonify([ms.to_json() for ms in ms_list])
+
+
+@app.route('/site_annotations', methods=['GET', 'POST'])
+def site_annotations():
+    site_list = request.json.get('site_list')
+    if site_list is None:
+        abort(Response('The required site_list argument is missing.', 400))
+
+    for site in site_list:
+        if len(site) != 3:
+            abort(Response('Site list entries need to have exactly 3 elements.',
+                           400))
+    site_annotations = get_site_annotations(site_list)
+    return jsonify(site_annotations)

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -1,4 +1,3 @@
-from nose.plugins.attrib import attr
 from protmapper.phosphosite_client import map_to_human_site, sites_only, \
                                           PspMapping
 

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -2,24 +2,24 @@ import os
 from collections import Counter
 from os.path import join, abspath, dirname, isfile
 import pickle
-from nose.tools import raises
+import pytest
 from protmapper.api import ProtMapper, _validate_site, MappedSite, \
                            InvalidSiteException, _get_uniprot_id
 
 
-@raises(InvalidSiteException)
 def test_validate_invalid_residue1():
-    _validate_site('B', '185')
+    with pytest.raises(InvalidSiteException):
+        _validate_site('B', '185')
 
 
-@raises(InvalidSiteException)
 def test_validate_invalid_residue2():
-    _validate_site('T', 'foo')
+    with pytest.raises(InvalidSiteException):
+        _validate_site('T', 'foo')
 
 
-@raises(InvalidSiteException)
 def test_validate_invalid_residue3():
-    _validate_site('T', '12.5')
+    with pytest.raises(InvalidSiteException):
+        _validate_site('T', '12.5')
 
 
 def test_validate_site():
@@ -110,10 +110,10 @@ def test_map_invalid_position2():
             description='Position 12.5 not a valid sequence position.')
 
 
-@raises(ValueError)
 def test_invalid_prot_ns():
     sm = ProtMapper()
-    sm.map_to_human_ref('MAPK1', 'hgncsymb', 'T', '185')
+    with pytest.raises(ValueError):
+        sm.map_to_human_ref('MAPK1', 'hgncsymb', 'T', '185')
 
 
 def test_check_agent_mod_up_id():

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -1,21 +1,21 @@
+import pytest
 from protmapper import uniprot_client
 from protmapper.resources import _process_feature, parse_uniprot_synonyms
-from nose.plugins.attrib import attr
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_query_protein_exists():
     tree = uniprot_client.query_protein('P00533')
     assert tree is not None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_query_protein_nonexist():
     tree = uniprot_client.query_protein('XXXX')
     assert tree is None
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_query_protein_deprecated():
     tree = uniprot_client.query_protein('Q8NHX1')
     assert tree is not None
@@ -25,7 +25,7 @@ def test_query_protein_deprecated():
     assert gene_name == 'MAPK3'
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_family_members():
     members = uniprot_client.get_family_members(
         'protein kinase superfamily TKL Ser/Thr protein kinase family RAF subfamily')
@@ -76,7 +76,7 @@ def test_get_gene_name_unreviewed():
     assert gene_name == 'EXO5'
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_gene_name_no_gene_name():
     gene_name = uniprot_client.get_gene_name('P04434', web_fallback=False)
     assert gene_name is None
@@ -101,20 +101,20 @@ def test_noentry_is_human():
     assert not uniprot_client.is_human('XXXX')
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_sequence():
     seq = uniprot_client.get_sequence('P00533')
     assert len(seq) > 1000
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_modifications():
     mods = uniprot_client.get_modifications('P27361')
     assert ('Phosphothreonine', 202) in mods, mods
     assert ('Phosphotyrosine', 204) in mods, mods
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_verify_location():
     assert uniprot_client.verify_location('P27361', 'T', 202)
     assert not uniprot_client.verify_location('P27361', 'S', 202)
@@ -184,7 +184,7 @@ def test_length():
     assert uniprot_client.get_length('P15056') == 766
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_function():
     fun = uniprot_client.get_function('P15056')
     assert fun.startswith('Protein kinase involved in the transduction')
@@ -203,7 +203,7 @@ def test_get_ids_from_refseq():
     assert up_ids == ['P31946-1']
 
 
-@attr('webservice')
+@pytest.mark.webservice
 def test_get_signal_peptide():
     # This is a valid entry local to the resource file
     sp = uniprot_client.get_signal_peptide('P00533')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,14 @@ rest_api = [
     "flask",
     "flask_cors",
 ]
+tests = [
+    "pytest",
+    "pytest-cov"
+]
 
 [project.scripts]
 protmapper = "protmapper.cli:main"
 
 [build-system]
-requires  ["setuptools", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,8 @@ protmapper = "protmapper.cli:main"
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "webservice: marks tests that rely on third-party webservices",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "protmapper"
+version = "0.0.29"
+description = "Map protein sites to human reference sequence."
+keywords = ["protein", "proteomics", "sequence", "alignment", "assembly", "post-translational", "modification"]
+readme = "README.md"
+authors = [
+    {name = "John A. Bachman", email = "bachmanjohn@gmail.com"},
+    {name = "Benjamin M. Gyori", email = "b.gyori@northeastern.edu"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+dependencies = [
+    "boto3",
+    "pystow>=0.1.0",
+    "requests",
+    "tqdm",
+]
+requires-python = ">=3.8"
+
+[project.urls]
+Homepage = "https://github.com/gyorilab/protmapper"
+
+[project.optional-dependencies]
+rest_api = [
+    "flask",
+    "flask_cors",
+]
+
+[project.scripts]
+protmapper = "protmapper.cli:main"
+
+[build-system]
+requires  ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def main():
                     'assembly', 'post-translational', 'modification'],
           packages=find_packages(),
           install_requires=install_list,
-          tests_require=['nose'],
+          tests_require=['pytest'],
           extras_require={'rest_api': ['flask', 'flask_cors']},
           include_package_data=True,
           entry_points={'console_scripts':

--- a/setup.py
+++ b/setup.py
@@ -1,54 +1,6 @@
-import re
-from os import path
-from setuptools import setup, find_packages
-
-
-here = path.abspath(path.dirname(__file__))
-with open(path.join(here, 'README.md'), 'r', encoding='utf-8') as fh:
-    long_description = fh.read()
-
-
-with open(path.join(here, 'protmapper', '__init__.py'), 'r') as fh:
-    for line in fh.readlines():
-        match = re.match(r'__version__ = \'(.+)\'', line)
-        if match:
-            version = match.groups()[0]
-            break
-    else:
-        raise ValueError('Could not get version from protmapper/__init__.py')
-
-
-def main():
-    install_list = ['requests', 'boto3', 'pystow>=0.1.0', 'tqdm']
-
-    setup(name='protmapper',
-          version=version,
-          description='Map protein sites to human reference sequence.',
-          long_description=long_description,
-          long_description_content_type='text/markdown',
-          author='John A. Bachman',
-          author_email='john_bachman@hms.harvard.edu',
-          url='https://github.com/indralab/protmapper',
-          classifiers=[
-            'Development Status :: 4 - Beta',
-            'Environment :: Console',
-            'Intended Audience :: Science/Research',
-            'License :: OSI Approved :: BSD License',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python :: 3',
-            'Topic :: Scientific/Engineering :: Bio-Informatics',
-            ],
-          keywords=['protein', 'proteomics', 'sequence', 'alignment',
-                    'assembly', 'post-translational', 'modification'],
-          packages=find_packages(),
-          install_requires=install_list,
-          tests_require=['pytest', 'pytest-cov'],
-          extras_require={'rest_api': ['flask', 'flask_cors']},
-          include_package_data=True,
-          entry_points={'console_scripts':
-                        ['protmapper = protmapper.cli:main']},
-        )
+import setuptools
 
 
 if __name__ == '__main__':
-    main()
+    setuptools.setup()
+

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def main():
                     'assembly', 'post-translational', 'modification'],
           packages=find_packages(),
           install_requires=install_list,
-          tests_require=['pytest'],
+          tests_require=['pytest', 'pytest-cov'],
           extras_require={'rest_api': ['flask', 'flask_cors']},
           include_package_data=True,
           entry_points={'console_scripts':

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'protmapper', '__init__.py'), 'r') as fh:
 
 
 def main():
-    install_list = ['requests', 'boto3', 'pystow>=0.1.0']
+    install_list = ['requests', 'boto3', 'pystow>=0.1.0', 'tqdm']
 
     setup(name='protmapper',
           version=version,


### PR DESCRIPTION
This PR makes the following changes
- Compatibility and testing up to Python 3.12
- Modernize by migrating to pyproject.toml from setup.py
- Migration from nosetests to pytest
- Add high-level function to do mapping to avoid having to use a mapper class
- Load site annotations as a resource and add function to return annotations for a given site
- Usage examples in the README